### PR TITLE
Fix video corruption when switching back from hires to lores

### DIFF
--- a/Spin/cody_line.spin
+++ b/Spin/cody_line.spin
@@ -285,7 +285,6 @@ render_chars_hi
                 
                 ' Precalculate the current offset for each character based on the scanline
                 mov     char_offset_y, curr_scanline
-                add     char_offset_y, adjustv
                 and     char_offset_y, #%0111
                 
                 ' Determine offset in the screen and color memory based on the current row

--- a/Spin/cody_line.spin
+++ b/Spin/cody_line.spin
@@ -358,11 +358,10 @@ if_c            or      pixel_data, #%01
                 shr     pixel_data, #2
                 
                 ' Write the pixel and color information to the buffer
-                wrword  pixel_data, dest_ptr
-                add     dest_ptr, #2
-                
-                wrword  color_data, dest_ptr
-                add     dest_ptr, #2
+                shl     color_data, #16
+                or      color_data, pixel_data
+                wrlong  color_data, dest_ptr
+                add     dest_ptr, #4
                 
                 ' Move to the next character
                 add     curr_screen_ptr, curr_screen_adv

--- a/Spin/cody_video.spin
+++ b/Spin/cody_video.spin
@@ -897,7 +897,7 @@ if_nz           sub     count, #2
                 ' If the display is enabled, draw the pixels from the buffer
                 ' If the display is shut off, draw the border color instead
                 test    control, #%00000001 wz
-if_z            waitvid colors, pixels
+if_z            waitvid colors, lores_pixels
 if_nz           waitvid border, #0
                 
                 ' Go on to the next four pixels
@@ -916,7 +916,7 @@ if_nz           waitvid border, #0
                 mov     VSCL, vsclactvhi
                 
 :hires_loop     ' Read the next eight pixels from the scanline buffer
-                rdword  pixels, source
+                rdword  hires_pixels, source
                 add     source, #2
                 
                 ' Read the colors for the 8x8 tile from the scanline buffer
@@ -926,7 +926,7 @@ if_nz           waitvid border, #0
                 ' If the display is enabled, draw the pixels from the buffer
                 ' If the display is shut off, draw the border color instead
                 test    control, #%00000001 wz
-if_z            waitvid colors, pixels
+if_z            waitvid colors, hires_pixels
 if_nz           waitvid border, #0
                 
                 ' Go on to the next eight pixels
@@ -967,7 +967,8 @@ numline                 long    $0                  ' Number of lines to emit (u
 count                   long    $0                  ' General-purpose counting value (used in certain loops)
 temp                    long    $0                  ' General-purpose temporary value
 
-pixels                  long    %%3210              ' Pixel pattern for four-color WAITVID operations
+lores_pixels            long    %%3210              ' Pixel pattern for low-resolution four-color WAITVIDs
+hires_pixels            long    %0                  ' Pixel pattern for high-resolution four-color WAITVIDs
 colors                  long    $0                  ' Current colors (pixels) to display on a scanline 
 border                  long    $0                  ' Current border color to use on borders/blanked screen
 control                 long    $0                  ' Current control register value


### PR DESCRIPTION
Fixes a bug introduced in the new high-resolution mode. When switching back from high-res to low-res the low-res screen would either go blank or be corrupted.

My initial suspicion centered on the NTSC cog and the scanline cogs getting out of sync, so I cleaned up some of that code, much of which is almost a decade old at this point. I think the new approach for syncing up the cogs is a lot easier to understand. However, that wasn't the problem.

The actual problem was that in the low-resolution mode we had a constant pixel pattern `%3210` and the scanline renderer generated a sequence of four colors to go with the known pixel pattern. When I added the high-resolution mode the previously-constant pixel pattern was actually getting changed, which worked correctly as long as we were in the high-resolution mode. When we switched back to the low-resolution mode, the last pixel pattern (whatever it was) would stick  around; we would get the correct *colors* on the screen but they would be garbled/out-of-order. 

Fixes #15 
