### PR TITLE
Add Makefile for building and uploading the Spin code

### DIFF
--- a/Spin/Makefile
+++ b/Spin/Makefile
@@ -26,9 +26,13 @@ codybasic.bin: ../Tass/codybasic.asm
 cody_computer.binary: cody_computer.spin $(CODY_COMPUTER_DEPS)
 	$(OPENSPIN) -o $@ $<
 
+ifneq ($(PORT),)
+    PROPLOADER_FLAGS += -p "$(PORT)"
+endif
+
 .PHONY: upload
 upload: cody_computer.binary
-	$(PROPLOADER) -e -r -s $<
+	$(PROPLOADER) $(PROPLOADER_FLAGS) -e -r -s $<
 
 # Not deleting codybasic.bin, because it is committed into Git.
 .PHONY: clean

--- a/Spin/Makefile
+++ b/Spin/Makefile
@@ -28,7 +28,7 @@ cody_computer.binary: cody_computer.spin $(CODY_COMPUTER_DEPS)
 
 .PHONY: upload
 upload: cody_computer.binary
-	$(PROPLOADER) -e -s $<
+	$(PROPLOADER) -e -r -s $<
 
 # Not deleting codybasic.bin, because it is committed into Git.
 .PHONY: clean

--- a/Spin/Makefile
+++ b/Spin/Makefile
@@ -1,0 +1,27 @@
+OPENSPIN ?= openspin
+PROPLOADER ?= proploader
+
+CODY_COMPUTER_DEPS = \
+    cody_audio.spin \
+    cody_line.spin \
+    cody_uart.spin \
+    cody_video.spin \
+    codybasic.bin
+
+.PHONY: all
+all: cody_computer.binary
+
+codybasic.bin: ../Tass/codybasic.asm
+	$(MAKE) -C ../Tass $@
+	cp ../Tass/$@ $@
+
+cody_computer.binary: cody_computer.spin $(CODY_COMPUTER_DEPS)
+	$(OPENSPIN) -o $@ $<
+
+.PHONY: upload
+upload: cody_computer.binary
+	$(PROPLOADER) -s $<
+
+.PHONY: clean
+clean:
+	$(RM) *.binary

--- a/Spin/Makefile
+++ b/Spin/Makefile
@@ -20,7 +20,7 @@ cody_computer.binary: cody_computer.spin $(CODY_COMPUTER_DEPS)
 
 .PHONY: upload
 upload: cody_computer.binary
-	$(PROPLOADER) -s $<
+	$(PROPLOADER) -e -s $<
 
 .PHONY: clean
 clean:

--- a/Spin/Makefile
+++ b/Spin/Makefile
@@ -1,4 +1,9 @@
+# If the Parallax tools are not in the PATH,
+# set the following environment variables to the complete paths to the respective tool executables.
+
+# Parallax OpenSpin: https://github.com/parallaxinc/OpenSpin
 OPENSPIN ?= openspin
+# Parallax PropLoader: https://github.com/parallaxinc/PropLoader
 PROPLOADER ?= proploader
 
 CODY_COMPUTER_DEPS = \
@@ -11,6 +16,9 @@ CODY_COMPUTER_DEPS = \
 .PHONY: all
 all: cody_computer.binary
 
+# Rebuild/re-copy the Cody BASIC ROM image if necessary.
+# Normally the codybasic.bin committed into the Git repo is always up-to-date,
+# but it may need updating if there are local changes to codybasic.asm.
 codybasic.bin: ../Tass/codybasic.asm
 	$(MAKE) -C ../Tass $@
 	cp ../Tass/$@ $@
@@ -22,6 +30,7 @@ cody_computer.binary: cody_computer.spin $(CODY_COMPUTER_DEPS)
 upload: cody_computer.binary
 	$(PROPLOADER) -e -s $<
 
+# Not deleting codybasic.bin, because it is committed into Git.
 .PHONY: clean
 clean:
 	$(RM) *.binary


### PR DESCRIPTION
As an alternative to the workflow based on the Propeller IDE, for users who cannot use the Propeller IDE for some reason (e. g. I couldn't find an arm64 build of the Propeller IDE) or who simply prefer the command line.

Tested on Linux (Debian 12, Linux 6.1.0-32-arm64), using Parallax [OpenSpin](https://github.com/parallaxinc/OpenSpin) and [PropLoader](https://github.com/parallaxinc/PropLoader) built from source.